### PR TITLE
Add user login system with sqlite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,3 +66,19 @@ target_link_libraries(${PROJECT_NAME} PRIVATE raylib)
 endif()
 
 # ---------- ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+# Include and link the sqlite3 library
+# ---------- ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+include_directories("${CMAKE_CURRENT_LIST_DIR}/include/sqlite3")
+link_directories("${CMAKE_CURRENT_LIST_DIR}/lib/sqlite3")
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+include_directories("/usr/include/sqlite3")
+link_directories("/usr/lib")
+endif()
+
+target_link_libraries(${PROJECT_NAME} PRIVATE sqlite3)
+
+# ---------- ---------- ---------- ---------- ---------- ---------- ---------- ---------- ----------

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -1,0 +1,99 @@
+#include "database.h"
+#include <sqlite3.h>
+#include <iostream>
+
+sqlite3 *db;
+
+void initializeDatabase() {
+    int rc = sqlite3_open("osu.db", &db);
+    if (rc) {
+        std::cerr << "Can't open database: " << sqlite3_errmsg(db) << std::endl;
+        return;
+    }
+
+    const char *sql_create_users = "CREATE TABLE IF NOT EXISTS users ("
+                                   "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                                   "username TEXT NOT NULL UNIQUE,"
+                                   "password TEXT NOT NULL);";
+
+    const char *sql_create_scores = "CREATE TABLE IF NOT EXISTS scores ("
+                                    "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                                    "username TEXT NOT NULL,"
+                                    "score INTEGER NOT NULL,"
+                                    "FOREIGN KEY(username) REFERENCES users(username));";
+
+    char *errMsg = nullptr;
+    rc = sqlite3_exec(db, sql_create_users, nullptr, nullptr, &errMsg);
+    if (rc != SQLITE_OK) {
+        std::cerr << "SQL error: " << errMsg << std::endl;
+        sqlite3_free(errMsg);
+    }
+
+    rc = sqlite3_exec(db, sql_create_scores, nullptr, nullptr, &errMsg);
+    if (rc != SQLITE_OK) {
+        std::cerr << "SQL error: " << errMsg << std::endl;
+        sqlite3_free(errMsg);
+    }
+}
+
+bool addUser(const std::string &username, const std::string &password) {
+    const char *sql = "INSERT INTO users (username, password) VALUES (?, ?);";
+    sqlite3_stmt *stmt;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+        std::cerr << "Failed to prepare statement: " << sqlite3_errmsg(db) << std::endl;
+        return false;
+    }
+
+    sqlite3_bind_text(stmt, 1, username.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 2, password.c_str(), -1, SQLITE_STATIC);
+
+    rc = sqlite3_step(stmt);
+    if (rc != SQLITE_DONE) {
+        std::cerr << "Failed to execute statement: " << sqlite3_errmsg(db) << std::endl;
+        sqlite3_finalize(stmt);
+        return false;
+    }
+
+    sqlite3_finalize(stmt);
+    return true;
+}
+
+bool checkUserCredentials(const std::string &username, const std::string &password) {
+    const char *sql = "SELECT * FROM users WHERE username = ? AND password = ?;";
+    sqlite3_stmt *stmt;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+        std::cerr << "Failed to prepare statement: " << sqlite3_errmsg(db) << std::endl;
+        return false;
+    }
+
+    sqlite3_bind_text(stmt, 1, username.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 2, password.c_str(), -1, SQLITE_STATIC);
+
+    rc = sqlite3_step(stmt);
+    bool result = (rc == SQLITE_ROW);
+
+    sqlite3_finalize(stmt);
+    return result;
+}
+
+void saveUserScore(const std::string &username, int score) {
+    const char *sql = "INSERT INTO scores (username, score) VALUES (?, ?);";
+    sqlite3_stmt *stmt;
+    int rc = sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+        std::cerr << "Failed to prepare statement: " << sqlite3_errmsg(db) << std::endl;
+        return;
+    }
+
+    sqlite3_bind_text(stmt, 1, username.c_str(), -1, SQLITE_STATIC);
+    sqlite3_bind_int(stmt, 2, score);
+
+    rc = sqlite3_step(stmt);
+    if (rc != SQLITE_DONE) {
+        std::cerr << "Failed to execute statement: " << sqlite3_errmsg(db) << std::endl;
+    }
+
+    sqlite3_finalize(stmt);
+}

--- a/src/database.h
+++ b/src/database.h
@@ -1,0 +1,11 @@
+#ifndef DATABASE_H
+#define DATABASE_H
+
+#include <string>
+
+void initializeDatabase();
+bool addUser(const std::string &username, const std::string &password);
+bool checkUserCredentials(const std::string &username, const std::string &password);
+void saveUserScore(const std::string &username, int score);
+
+#endif // DATABASE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,8 @@
 #include <raylib.h>
 #include <raymath.h>
 
+#include <sqlite3.h>
+
 #define RAYGUI_IMPLEMENTATION
 #include "raygui.hpp"
 
@@ -34,6 +36,7 @@ Sound key_press_1 = {0};
 int score = 0;
 int streak = 0;
 float time_diff = 0.0f;
+std::string current_user;
 
 void centerWindow(int width, int height)
 {
@@ -261,6 +264,9 @@ void osuRun() {
         EndDrawing();
     }
 
+    // Save the user's score in the database
+    saveUserScore(current_user, score);
+
     // Unload the music
     UnloadMusicStream(music);
     // Close the audio device
@@ -271,8 +277,31 @@ void osuRun() {
     return;
 }
 
+void handleUserLogin() {
+    std::string username;
+    std::string password;
+
+    std::cout << "Enter username: ";
+    std::cin >> username;
+    std::cout << "Enter password: ";
+    std::cin >> password;
+
+    if (checkUserCredentials(username, password)) {
+        current_user = username;
+        std::cout << "Login successful!" << std::endl;
+    } else {
+        std::cout << "Invalid credentials. Please try again." << std::endl;
+        handleUserLogin();
+    }
+}
+
 int main()
 {
+    // Initialize the database
+    initializeDatabase();
+
+    // Handle user login
+    handleUserLogin();
 
     InitWindow(400, 400, "Raylib osu!");
     SetTargetFPS(120);


### PR DESCRIPTION
Add user login system and score saving functionality using sqlite3.

* **CMakeLists.txt**
  - Include and link the sqlite3 library for both Windows and Linux systems.

* **src/main.cpp**
  - Include sqlite3 header.
  - Add `current_user` variable to store the logged-in user's name.
  - Add `handleUserLogin` function to manage user login.
  - Modify `main` function to initialize the database and handle user login before starting the game.
  - Modify `osuRun` function to save the user's score in the database after the game ends.

* **src/database.cpp**
  - Add functions to initialize the sqlite3 database and create tables for users and scores.
  - Add functions to add a new user, check user credentials, and save user scores.

* **src/database.h**
  - Add function declarations for initializing the database, adding a new user, checking user credentials, and saving user scores.

